### PR TITLE
fix UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in posiion 10: ordinal not in range(128) on plugin_loaded (ST2)

### DIFF
--- a/WakaTime.py
+++ b/WakaTime.py
@@ -282,7 +282,7 @@ def find_python_in_folder(folder, headless=True):
         if not retcode and pattern.search(output):
             return path
     except:
-        log(DEBUG, u('Python Version Output: {0}').format(u(sys.exc_info()[1])))
+        log(DEBUG, u('Python Version Output: {0}').format(u(str(sys.exc_info()[1]))))
 
     if headless:
         path = find_python_in_folder(folder, headless=False)


### PR DESCRIPTION
Hi Alan!

Context: **SublimeText2**

I have a non english local on linux desktop and has a bug (on load or reload plugin):
```python 
[WakaTime] [INFO] Initializing WakaTime plugin v6.0.3
Traceback (most recent call last):
  File "./sublime_plugin.py", line 62, in reload_plugin
  File "./WakaTime.py", line 517, in <module>
    plugin_loaded()
  File "./WakaTime.py", line 498, in plugin_loaded
    if not python_binary():
  File "./WakaTime.py", line 185, in python_binary
    path = find_python_in_folder(path)
  File "./WakaTime.py", line 285, in find_python_in_folder
    log(DEBUG, u('Python Version Output: {0}').format(u(sys.exc_info()[1])))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 10: ordinal not in range(128)
+ Info: processing `Python': please wait...
```
For example sys.excinfo (for russian local): 
```python
(<type 'exceptions.OSError'>, OSError(2, '\xd0\x9d\xd0\xb5\xd1\x82 \xd1\x82\xd0\xb0\xd0\xba\xd0\xbe\xd0\xb3\xd0\xbe \xd1\x84\xd0\xb0\xd0\xb9\xd0\xbb\xd0\xb0 \xd0\xb8\xd0\xbb\xd0\xb8 \xd0\xba\xd0\xb0\xd1\x82\xd0\xb0\xd0\xbb\xd0\xbe\xd0\xb3\xd0\xb0'), <traceback object at 0x7f68948ffef0>)
```

Simple fix is: 
change: log(DEBUG, u('Python Version Output: {0}').format(u(sys.exc_info()[1])))
to: log(DEBUG, u('Python Version Output: {0}').format(u(str(sys.exc_info()[1]))))
