### PR TITLE
strip the output

### DIFF
--- a/WakaTime.py
+++ b/WakaTime.py
@@ -335,7 +335,7 @@ class FetchStatusBarCodingTime(threading.Thread):
         try:
             process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
             output, err = process.communicate()
-            output = u(output)
+            output = u(output).strip()
             retcode = process.poll()
             if not retcode and output:
                 msg = 'Today: {output}'.format(output=output)


### PR DESCRIPTION
I have found text from other plugins will not be displayed behind wakatime in the status bar.
same condition as #97 
now it seems fine.
