### PR TITLE
Fix Python 3.8 warning when getting Unix time zone

### DIFF
--- a/packages/wakatime/packages/tzlocal/unix.py
+++ b/packages/wakatime/packages/tzlocal/unix.py
@@ -97,7 +97,7 @@ def _get_localzone(_root='/'):
     if os.path.exists(tzpath) and os.path.islink(tzpath):
         tzpath = os.path.realpath(tzpath)
         start = tzpath.find("/")+1
-        while start is not 0:
+        while start != 0:
             tzpath = tzpath[start:]
             try:
                 return pytz.timezone(tzpath)


### PR DESCRIPTION
I noticed a WakaTime error in my status bar today when installing this package. `SyntaxWarning: "is not" with a literal. Did you mean "!="?"`

My Python version is 3.9.7 and I think this warning got added in Python 3.8.

This small fix swaps `is not 0` for `!= 0` which should fix the problem.

I tested this locally by installing the modified package and making sure my WakaTime dashboard was still being updated correctly.

Thank you!